### PR TITLE
Fixing a typo in requirements

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,4 +1,4 @@
-Ractive = require 'Ractive'
+Ractive = require 'ractive'
 umd = require 'umd-wrapper'
 sysPath = require 'path'
 


### PR DESCRIPTION
The module should be required as "ractive" instead of "Ractive".
